### PR TITLE
Changed around test structure to take advantage of new --config flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "jest": "jest",
     "lint": "eslint lib/*.js",
     "lint.fix": "eslint --fix lib/*.js",
-    "test": "bst test",
-    "test-e2e": "cd e2e && bst test"
+    "test": "bst test --config test/testing.json test/*.yml",
+    "test-e2e": "bst test --config e2e/testing.json e2e/*.yml"
   },
   "author": "",
   "license": "ISC",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "babel-jest": "^22.4.3",
-    "bespoken-tools": "^2.4.10",
+    "bespoken-tools": "beta",
     "codecov": "^3.5.0",
     "eslint": "^5.16.0",
     "eslint-plugin-jest": "^22.5.1",

--- a/test/testing.json
+++ b/test/testing.json
@@ -6,11 +6,10 @@
     "handler": "lib/index.js",
     "jest": {
       "collectCoverage": true,
-      "collectCoverageFrom": ["../lib/*.js"],
+      "collectCoverageFrom": ["lib/*.js"],
       "coveragePathIgnorePatterns": [
         "<rootDir>/data"
       ],
-      "silent": false,
-      "testPathIgnorePatterns": ["e2e"]
+      "silent": false
     }
   }


### PR DESCRIPTION
Moved top-level testing.json to test folder
Made paths relative to root
No need to chdir to run e2e tests anymore
